### PR TITLE
feat. add named corners to the OrientedBoundingBox

### DIFF
--- a/src/Cube/index.ts
+++ b/src/Cube/index.ts
@@ -1,2 +1,2 @@
-import { CubeCorners } from './interface';
-export { CubeCorners };
+import { CubeCorners, NamedCubeCorners } from './interface';
+export { CubeCorners, NamedCubeCorners };

--- a/src/Cube/interface.ts
+++ b/src/Cube/interface.ts
@@ -10,3 +10,14 @@ export type CubeCorners = [
     IPosition3D,
     IPosition3D
 ];
+
+export type NamedCubeCorners = {
+    'left-top-rear': IPosition3D;
+    'right-top-rear': IPosition3D;
+    'left-bottom-rear': IPosition3D;
+    'right-bottom-rear': IPosition3D;
+    'left-top-front': IPosition3D;
+    'right-top-front': IPosition3D;
+    'left-bottom-front': IPosition3D;
+    'right-bottom-front': IPosition3D;
+};

--- a/src/OrientedBoundingBox/OrientedBoundingBox.ts
+++ b/src/OrientedBoundingBox/OrientedBoundingBox.ts
@@ -4,7 +4,7 @@ import { IPosition3D } from '../Position';
 
 import { IOrientedBoundingBox } from './interface';
 import { Either } from 'fp-ts/lib/Either';
-import { CubeCorners } from '../Cube';
+import { CubeCorners, NamedCubeCorners } from '../Cube';
 
 export class OrientedBoundingBox implements IOrientedBoundingBox {
     private _aabb: AxisAlignedBoundingBox;
@@ -30,6 +30,18 @@ export class OrientedBoundingBox implements IOrientedBoundingBox {
     }
     public corners(): Either<string, CubeCorners> {
         return this._transform.cornersFromAxisAlignedBoundingBox(this._aabb);
+    }
+    public namedCorners(): Either<string, NamedCubeCorners> {
+        return this.corners().map(corners => ({
+            'left-top-rear': corners[0],
+            'right-top-rear': corners[1],
+            'left-bottom-rear': corners[2],
+            'right-bottom-rear': corners[3],
+            'left-top-front': corners[4],
+            'right-top-front': corners[5],
+            'left-bottom-front': corners[6],
+            'right-bottom-front': corners[7],
+        }));
     }
     public axisAlignedBoundingBox() {
         return this._transform.axisAlignedBoundingBox(this._aabb);

--- a/src/OrientedBoundingBox/interface.ts
+++ b/src/OrientedBoundingBox/interface.ts
@@ -3,7 +3,7 @@ import { Either } from 'fp-ts/lib/Either';
 import { IPosition3D } from '../Position';
 import { AxisAlignedBoundingBox } from '../AxisAlignedBoundingBox';
 import { AffineTransform3D } from '../AffineTransform';
-import { CubeCorners } from '../Cube';
+import { CubeCorners, NamedCubeCorners } from '../Cube';
 
 export interface IOrientedBoundingBox {
     /**
@@ -18,6 +18,10 @@ export interface IOrientedBoundingBox {
      * the corners of the OrientedBoundedBox
      */
     corners(): Either<string, CubeCorners>;
+    /**
+     * the {@link NamedCubeCorners} of the OrientedBoundingBox
+     */
+    namedCorners(): Either<string, NamedCubeCorners>;
     /**
      * the internal AxisAlignedBoundingBox this OrientedBoundingBox is constructed with
      */


### PR DESCRIPTION
Adding a data structure to map the names for corners for a Cube to an `OrientedBoundingBox`'s corners for convenience.