### PR TITLE
Feature/expose return types

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "tabWidth": 4,
+  "singleQuote": true,
+  "arrowParens": "always"
+}

--- a/src/AffineTransform/index.ts
+++ b/src/AffineTransform/index.ts
@@ -3,10 +3,8 @@ import { right, left } from 'fp-ts/lib/Either';
 import { IAffineTransform } from './interface';
 import { SquareMatrix3D, Matrix } from '../Matrix';
 import { IVector, Vector } from '../Vector';
-import { IPosition3D as IPos3D, Position3D, IPosition3D } from '../Position';
-import {
-  AxisAlignedBoundingBox,
-} from '../AxisAlignedBoundingBox';
+import { Position3D, IPosition3D } from '../Position';
+import { AxisAlignedBoundingBox } from '../AxisAlignedBoundingBox';
 import { CubeCorners } from '../Cube';
 import { Pair } from '../util/Pair';
 import { FineResult } from '../interface';
@@ -46,7 +44,7 @@ export class AffineTransform3D implements IAffineTransform {
         )
     );
   }
-  public position(pos: IPos3D): FineResult<string, IPosition3D> {
+  public position(pos: IPosition3D): FineResult<string, IPosition3D> {
     return this._transform
       .multiply(Matrix.columnFromPos3D(pos))
       .chain(multipliedMatrix =>
@@ -60,8 +58,8 @@ export class AffineTransform3D implements IAffineTransform {
   ): FineResult<string, CubeCorners> {
     return this.rawCornersFromAxisAlignedBoundingBox(aabb).reduce(
       (
-        result: FineResult<string, Array<IPos3D>>,
-        eitherPos: FineResult<string, IPos3D>
+        result: FineResult<string, Array<IPosition3D>>,
+        eitherPos: FineResult<string, IPosition3D>
       ) => eitherPos.map(pos => result.getOrElse([]).concat(pos)),
       left('')
     ) as FineResult<string, CubeCorners>;

--- a/src/AffineTransform/index.ts
+++ b/src/AffineTransform/index.ts
@@ -3,8 +3,11 @@ import { right, left } from 'fp-ts/lib/Either';
 import { IAffineTransform } from './interface';
 import { SquareMatrix3D, Matrix } from '../Matrix';
 import { IVector, Vector } from '../Vector';
-import { IPosition3D as IPos3D, Position3D } from '../Position';
-import { AxisAlignedBoundingBox } from '../AxisAlignedBoundingBox';
+import { IPosition3D as IPos3D, Position3D, IPosition3D } from '../Position';
+import {
+  AxisAlignedBoundingBox,
+  IAxisAlignedBoundingBox
+} from '../AxisAlignedBoundingBox';
 import { CubeCorners } from '../Cube';
 import { Pair } from '../util/Pair';
 import { FineResult } from '../interface';
@@ -13,81 +16,77 @@ export { IAffineTransform };
 
 // TODO: export this to AffineTransform.ts
 export class AffineTransform3D implements IAffineTransform {
-    /**
-     * return the identity transform
-     */
-    public static identity(): AffineTransform3D {
-        return new AffineTransform3D(
-            SquareMatrix3D.identity(),
-            new Vector(3, [0, 0, 0]),
+  /**
+   * return the identity transform
+   */
+  public static identity(): AffineTransform3D {
+    return new AffineTransform3D(
+      SquareMatrix3D.identity(),
+      new Vector(3, [0, 0, 0])
+    );
+  }
+  constructor(
+    private _transform: SquareMatrix3D,
+    private _translation: IVector
+  ) {}
+
+  public inverse(): FineResult<string, IAffineTransform> {
+    return this._transform.inverse().chain(inverseMatrix =>
+      inverseMatrix
+        .multiply(new Matrix(3, 1, this._translation.value()))
+        // chain runs a fn `across` an Either, which means that
+        // if (and only if) the Either is a Right, the Either is
+        // unwrapped and passed to the function, and expects you to
+        // return another Either. This allows us to 'merge' two Eithers
+        // together.
+        // it behaves like map, in that this will only run if the Either is
+        // a Right
+        .chain(multipliedMatrix => Vector.fromMatrix(multipliedMatrix))
+        .chain(translationVector =>
+          right(new AffineTransform3D(inverseMatrix, translationVector))
+        )
+    );
+  }
+  public position(pos: IPos3D): FineResult<string, IPosition3D> {
+    return this._transform
+      .multiply(Matrix.columnFromPos3D(pos))
+      .chain(multipliedMatrix =>
+        multipliedMatrix.sum(Matrix.columnFromVector(this._translation))
+      )
+      .chain(matrix => Position3D.fromMatrix(matrix));
+  }
+
+  public cornersFromAxisAlignedBoundingBox(
+    aabb: AxisAlignedBoundingBox
+  ): FineResult<string, CubeCorners> {
+    return this.rawCornersFromAxisAlignedBoundingBox(aabb).reduce(
+      (
+        result: FineResult<string, Array<IPos3D>>,
+        eitherPos: FineResult<string, IPos3D>
+      ) => eitherPos.map(pos => result.getOrElse([]).concat(pos)),
+      left('')
+    ) as FineResult<string, CubeCorners>;
+  }
+
+  /**
+   * given an AxisAlignedBoundingBox, return a new AxisAlignedBoundingBox after the transform has been applied
+   */
+  public axisAlignedBoundingBox(
+    aabb: AxisAlignedBoundingBox
+  ): FineResult<string, AxisAlignedBoundingBox> {
+    return this.rawCornersFromAxisAlignedBoundingBox(aabb)
+      .reduce((result, eitherPos) => {
+        return eitherPos.chain(pos =>
+          result.map(
+            ([min, max]) =>
+              [pos.minimum(min), pos.maximum(max)] as Pair<Position3D>
+          )
         );
-    }
-    constructor(
-        private _transform: SquareMatrix3D,
-        private _translation: IVector,
-    ) {}
+      }, right([new Position3D(Infinity, Infinity, Infinity), new Position3D(-Infinity, -Infinity, -Infinity)] as [Position3D, Position3D]))
+      .map(([min, max]) => new AxisAlignedBoundingBox(min, max));
+  }
 
-    public inverse() {
-        return this._transform.inverse().chain(inverseMatrix =>
-            inverseMatrix
-                .multiply(new Matrix(3, 1, this._translation.value()))
-                // chain runs a fn `across` an Either, which means that
-                // if (and only if) the Either is a Right, the Either is
-                // unwrapped and passed to the function, and expects you to
-                // return another Either. This allows us to 'merge' two Eithers
-                // together.
-                // it behaves like map, in that this will only run if the Either is
-                // a Right
-                .chain(multipliedMatrix => Vector.fromMatrix(multipliedMatrix))
-                .chain(translationVector =>
-                    right(
-                        new AffineTransform3D(inverseMatrix, translationVector),
-                    ),
-                ),
-        );
-    }
-    public position(pos: IPos3D) {
-        return this._transform
-            .multiply(Matrix.columnFromPos3D(pos))
-            .chain(multipliedMatrix =>
-                multipliedMatrix.sum(
-                    Matrix.columnFromVector(this._translation),
-                ),
-            )
-            .chain(matrix => Position3D.fromMatrix(matrix));
-    }
-
-    public cornersFromAxisAlignedBoundingBox(
-        aabb: AxisAlignedBoundingBox,
-    ): FineResult<string, CubeCorners> {
-        return this.rawCornersFromAxisAlignedBoundingBox(aabb).reduce(
-            (
-                result: FineResult<string, Array<IPos3D>>,
-                eitherPos: FineResult<string, IPos3D>,
-            ) => eitherPos.map(pos => result.getOrElse([]).concat(pos)),
-            left(''),
-        ) as FineResult<string, CubeCorners>;
-    }
-
-    /**
-     * given an AxisAlignedBoundingBox, return a new AxisAlignedBoundingBox after the transform has been applied
-     */
-    public axisAlignedBoundingBox(aabb: AxisAlignedBoundingBox) {
-        return this.rawCornersFromAxisAlignedBoundingBox(aabb)
-            .reduce((result, eitherPos) => {
-                return eitherPos.chain(pos =>
-                    result.map(
-                        ([min, max]) =>
-                            [pos.minimum(min), pos.maximum(max)] as Pair<
-                                Position3D
-                            >,
-                    ),
-                );
-            }, right([new Position3D(Infinity, Infinity, Infinity), new Position3D(-Infinity, -Infinity, -Infinity)] as [Position3D, Position3D]))
-            .map(([min, max]) => new AxisAlignedBoundingBox(min, max));
-    }
-
-    private rawCornersFromAxisAlignedBoundingBox(aabb: AxisAlignedBoundingBox) {
-        return aabb.corners().map(pos => this.position(pos));
-    }
+  private rawCornersFromAxisAlignedBoundingBox(aabb: AxisAlignedBoundingBox) {
+    return aabb.corners().map(pos => this.position(pos));
+  }
 }

--- a/src/AffineTransform/index.ts
+++ b/src/AffineTransform/index.ts
@@ -1,4 +1,4 @@
-import { right, left, Either } from 'fp-ts/lib/Either';
+import { right, left } from 'fp-ts/lib/Either';
 
 import { IAffineTransform } from './interface';
 import { SquareMatrix3D, Matrix } from '../Matrix';
@@ -7,6 +7,7 @@ import { IPosition3D as IPos3D, Position3D } from '../Position';
 import { AxisAlignedBoundingBox } from '../AxisAlignedBoundingBox';
 import { CubeCorners } from '../Cube';
 import { Pair } from '../util/Pair';
+import { FineResult } from '../interface';
 
 export { IAffineTransform };
 
@@ -58,14 +59,14 @@ export class AffineTransform3D implements IAffineTransform {
 
     public cornersFromAxisAlignedBoundingBox(
         aabb: AxisAlignedBoundingBox,
-    ): Either<string, CubeCorners> {
+    ): FineResult<string, CubeCorners> {
         return this.rawCornersFromAxisAlignedBoundingBox(aabb).reduce(
             (
-                result: Either<string, Array<IPos3D>>,
-                eitherPos: Either<string, IPos3D>,
+                result: FineResult<string, Array<IPos3D>>,
+                eitherPos: FineResult<string, IPos3D>,
             ) => eitherPos.map(pos => result.getOrElse([]).concat(pos)),
             left(''),
-        ) as Either<string, CubeCorners>;
+        ) as FineResult<string, CubeCorners>;
     }
 
     /**

--- a/src/AffineTransform/index.ts
+++ b/src/AffineTransform/index.ts
@@ -11,79 +11,85 @@ import { FineResult } from '../interface';
 
 export { IAffineTransform };
 
-// TODO: export this to AffineTransform.ts
+// TODO: move this to AffineTransform.ts
 export class AffineTransform3D implements IAffineTransform {
-  /**
-   * return the identity transform
-   */
-  public static identity(): AffineTransform3D {
-    return new AffineTransform3D(
-      SquareMatrix3D.identity(),
-      new Vector(3, [0, 0, 0])
-    );
-  }
-  constructor(
-    private _transform: SquareMatrix3D,
-    private _translation: IVector
-  ) {}
-
-  public inverse(): FineResult<string, IAffineTransform> {
-    return this._transform.inverse().chain(inverseMatrix =>
-      inverseMatrix
-        .multiply(new Matrix(3, 1, this._translation.value()))
-        // chain runs a fn `across` an Either, which means that
-        // if (and only if) the Either is a Right, the Either is
-        // unwrapped and passed to the function, and expects you to
-        // return another Either. This allows us to 'merge' two Eithers
-        // together.
-        // it behaves like map, in that this will only run if the Either is
-        // a Right
-        .chain(multipliedMatrix => Vector.fromMatrix(multipliedMatrix))
-        .chain(translationVector =>
-          right(new AffineTransform3D(inverseMatrix, translationVector))
-        )
-    );
-  }
-  public position(pos: IPosition3D): FineResult<string, IPosition3D> {
-    return this._transform
-      .multiply(Matrix.columnFromPos3D(pos))
-      .chain(multipliedMatrix =>
-        multipliedMatrix.sum(Matrix.columnFromVector(this._translation))
-      )
-      .chain(matrix => Position3D.fromMatrix(matrix));
-  }
-
-  public cornersFromAxisAlignedBoundingBox(
-    aabb: AxisAlignedBoundingBox
-  ): FineResult<string, CubeCorners> {
-    return this.rawCornersFromAxisAlignedBoundingBox(aabb).reduce(
-      (
-        result: FineResult<string, Array<IPosition3D>>,
-        eitherPos: FineResult<string, IPosition3D>
-      ) => eitherPos.map(pos => result.getOrElse([]).concat(pos)),
-      left('')
-    ) as FineResult<string, CubeCorners>;
-  }
-
-  /**
-   * given an AxisAlignedBoundingBox, return a new AxisAlignedBoundingBox after the transform has been applied
-   */
-  public axisAlignedBoundingBox(
-    aabb: AxisAlignedBoundingBox
-  ): FineResult<string, AxisAlignedBoundingBox> {
-    return this.rawCornersFromAxisAlignedBoundingBox(aabb)
-      .reduce((result, eitherPos) => {
-        return eitherPos.chain(pos =>
-          result.map(
-            ([min, max]) =>
-              [pos.minimum(min), pos.maximum(max)] as Pair<Position3D>
-          )
+    /**
+     * return the identity transform
+     */
+    public static identity(): AffineTransform3D {
+        return new AffineTransform3D(
+            SquareMatrix3D.identity(),
+            new Vector(3, [0, 0, 0])
         );
-      }, right([new Position3D(Infinity, Infinity, Infinity), new Position3D(-Infinity, -Infinity, -Infinity)] as [Position3D, Position3D]))
-      .map(([min, max]) => new AxisAlignedBoundingBox(min, max));
-  }
+    }
+    constructor(
+        private _transform: SquareMatrix3D,
+        private _translation: IVector
+    ) {}
 
-  private rawCornersFromAxisAlignedBoundingBox(aabb: AxisAlignedBoundingBox) {
-    return aabb.corners().map(pos => this.position(pos));
-  }
+    public inverse(): FineResult<string, IAffineTransform> {
+        return this._transform.inverse().chain((inverseMatrix) =>
+            inverseMatrix
+                .multiply(new Matrix(3, 1, this._translation.value()))
+                // chain runs a fn `across` an Either, which means that
+                // if (and only if) the Either is a Right, the Either is
+                // unwrapped and passed to the function, and expects you to
+                // return another Either. This allows us to 'merge' two Eithers
+                // together.
+                // it behaves like map, in that this will only run if the Either is
+                // a Right
+                .chain((multipliedMatrix) =>
+                    Vector.fromMatrix(multipliedMatrix)
+                )
+                .chain((translationVector) =>
+                    right(
+                        new AffineTransform3D(inverseMatrix, translationVector)
+                    )
+                )
+        );
+    }
+    public position(pos: IPosition3D): FineResult<string, IPosition3D> {
+        return this._transform
+            .multiply(Matrix.columnFromPos3D(pos))
+            .chain((multipliedMatrix) =>
+                multipliedMatrix.sum(Matrix.columnFromVector(this._translation))
+            )
+            .chain((matrix) => Position3D.fromMatrix(matrix));
+    }
+
+    public cornersFromAxisAlignedBoundingBox(
+        aabb: AxisAlignedBoundingBox
+    ): FineResult<string, CubeCorners> {
+        return this.rawCornersFromAxisAlignedBoundingBox(aabb).reduce(
+            (
+                result: FineResult<string, Array<IPosition3D>>,
+                eitherPos: FineResult<string, IPosition3D>
+            ) => eitherPos.map((pos) => result.getOrElse([]).concat(pos)),
+            left('')
+        ) as FineResult<string, CubeCorners>;
+    }
+
+    /**
+     * given an AxisAlignedBoundingBox, return a new AxisAlignedBoundingBox after the transform has been applied
+     */
+    public axisAlignedBoundingBox(
+        aabb: AxisAlignedBoundingBox
+    ): FineResult<string, AxisAlignedBoundingBox> {
+        return this.rawCornersFromAxisAlignedBoundingBox(aabb)
+            .reduce((result, eitherPos) => {
+                return eitherPos.chain((pos) =>
+                    result.map(
+                        ([min, max]) =>
+                            [pos.minimum(min), pos.maximum(max)] as Pair<
+                                Position3D
+                            >
+                    )
+                );
+            }, right([new Position3D(Infinity, Infinity, Infinity), new Position3D(-Infinity, -Infinity, -Infinity)] as [Position3D, Position3D]))
+            .map(([min, max]) => new AxisAlignedBoundingBox(min, max));
+    }
+
+    private rawCornersFromAxisAlignedBoundingBox(aabb: AxisAlignedBoundingBox) {
+        return aabb.corners().map((pos) => this.position(pos));
+    }
 }

--- a/src/AffineTransform/index.ts
+++ b/src/AffineTransform/index.ts
@@ -6,7 +6,6 @@ import { IVector, Vector } from '../Vector';
 import { IPosition3D as IPos3D, Position3D, IPosition3D } from '../Position';
 import {
   AxisAlignedBoundingBox,
-  IAxisAlignedBoundingBox
 } from '../AxisAlignedBoundingBox';
 import { CubeCorners } from '../Cube';
 import { Pair } from '../util/Pair';

--- a/src/AffineTransform/interface.ts
+++ b/src/AffineTransform/interface.ts
@@ -1,4 +1,4 @@
-import { Either } from 'fp-ts/lib/Either';
+import { FineResult } from '../interface';
 
 import { IPosition3D } from '../Position/interface';
 import { IAxisAlignedBoundingBox } from '../AxisAlignedBoundingBox/interface';
@@ -8,7 +8,7 @@ export interface IAffineTransform {
     /**
      * produce a new IAffineTransform3D which represents the inverse of this one
      */
-    inverse(): Either<string, IAffineTransform>;
+    inverse(): FineResult<string, IAffineTransform>;
     /**
      * transform the position provided.
      *  Possible Left values include:
@@ -16,7 +16,7 @@ export interface IAffineTransform {
      *   - Matrix.ERR_CANNOT_MULTIPLY_INCOMPATIBLE_DIMENSIONS
      *
      */
-    position(pos: IPosition3D): Either<string, IPosition3D>;
+    position(pos: IPosition3D): FineResult<string, IPosition3D>;
     /**
      * transform the AxisAlignedBoundingBox provided into a new AxisAlignedBoundingBox.
      *  Possible Left values include:
@@ -25,7 +25,7 @@ export interface IAffineTransform {
      */
     axisAlignedBoundingBox(
         aabb: IAxisAlignedBoundingBox,
-    ): Either<string, IAxisAlignedBoundingBox>;
+    ): FineResult<string, IAxisAlignedBoundingBox>;
 
     /**
      * given an axisAlignedBoundingBox, return the transformed corners.
@@ -35,5 +35,5 @@ export interface IAffineTransform {
      */
     cornersFromAxisAlignedBoundingBox(
         aabb: IAxisAlignedBoundingBox,
-    ): Either<string, CubeCorners>;
+    ): FineResult<string, CubeCorners>;
 }

--- a/src/Matrix/Matrix.ts
+++ b/src/Matrix/Matrix.ts
@@ -1,4 +1,4 @@
-import { Either, left, right } from 'fp-ts/lib/Either';
+import { left, right } from 'fp-ts/lib/Either';
 
 import { IPosition3D } from '../Position/interface';
 import { IVector, Vector } from '../Vector';
@@ -6,6 +6,7 @@ import { ZeroArray } from '../util/ZeroArray';
 import { Range } from '../util/Range';
 
 import { IMatrix } from './';
+import { FineResult } from '../interface';
 
 /**
  * a general i-by-j Matrix of numbers
@@ -35,7 +36,7 @@ export class Matrix implements IMatrix {
         rows: number,
         columns: number,
         array: Array<number>,
-    ): Either<string, Matrix> {
+    ): FineResult<string, Matrix> {
         return Matrix.invalidConstructor(array, rows, columns)
             ? left(Matrix.ERR_CANNOT_CONSTRUCT_INVALID_LENGTH)
             : right(new Matrix(rows, columns, array));
@@ -86,7 +87,7 @@ export class Matrix implements IMatrix {
     /**
      * sum two Matrices.
      */
-    public sum(rightMatrix: IMatrix): Either<string, Matrix> {
+    public sum(rightMatrix: IMatrix): FineResult<string, Matrix> {
         if (!this.matchesDimensions(rightMatrix)) {
             return left(Matrix.ERR_CANNOT_ADD_DIMENSIONS_DIFFER);
         }
@@ -139,7 +140,7 @@ export class Matrix implements IMatrix {
             return left<string, Vector>(Matrix.ERR_INDEX_OUT_OF_BOUNDS);
         }
     }
-    public multiply(rightMatrix: IMatrix): Either<string, Matrix> {
+    public multiply(rightMatrix: IMatrix): FineResult<string, Matrix> {
         // matrix multiplication can only occur if the number of the left Matrix's rows
         //   are equal to the number of the right Matrix's columns
         return this.columns() !== rightMatrix.rows()

--- a/src/Matrix/Matrix.ts
+++ b/src/Matrix/Matrix.ts
@@ -12,195 +12,186 @@ import { FineResult } from '../interface';
  * a general i-by-j Matrix of numbers
  */
 export class Matrix implements IMatrix {
-    public static ERR_CANNOT_CONSTRUCT_INVALID_LENGTH =
-        '[Matrix]: unable to construct Matrix with initial contents of invalid length';
-    public static ERR_CANNOT_ADD_DIMENSIONS_DIFFER =
-        '[Matrix]: unable to add matrices with differing dimensions';
-    public static ERR_CANNOT_MULTIPLY_INCOMPATIBLE_DIMENSIONS =
-        '[Matrix]: Unable to multiply matrices with incompatible dimensions';
-    public static ERR_INDEX_OUT_OF_BOUNDS =
-        '[Matrix]: Cannot retrieve, index provided is out of bounds';
-    /**
-     *  construct a rows-by-columns sized zero-matrix.
-     */
-    public static zeroMatrix(rows: number, columns: number): Matrix {
-        return new Matrix(rows, columns);
-    }
-    /**
-     * construct a Matrix from an existing array.
-     * validates that the array is the correct size, given the number of rows and columns.
-     * in the case that the array is the incorrect size, returns an Either.Left,
-     * otherwise returns an Either.Right of the constructed Matrix
-     */
-    public static fromArray(
-        rows: number,
-        columns: number,
-        array: Array<number>,
-    ): FineResult<string, Matrix> {
-        return Matrix.invalidConstructor(array, rows, columns)
-            ? left(Matrix.ERR_CANNOT_CONSTRUCT_INVALID_LENGTH)
-            : right(new Matrix(rows, columns, array));
-    }
-    public static rowFromPos3D(pos3D: IPosition3D): Matrix {
-        return new Matrix(1, 3, pos3D.value());
-    }
+  public static ERR_CANNOT_CONSTRUCT_INVALID_LENGTH =
+    '[Matrix]: unable to construct Matrix with initial contents of invalid length';
+  public static ERR_CANNOT_ADD_DIMENSIONS_DIFFER =
+    '[Matrix]: unable to add matrices with differing dimensions';
+  public static ERR_CANNOT_MULTIPLY_INCOMPATIBLE_DIMENSIONS =
+    '[Matrix]: Unable to multiply matrices with incompatible dimensions';
+  public static ERR_INDEX_OUT_OF_BOUNDS =
+    '[Matrix]: Cannot retrieve, index provided is out of bounds';
+  /**
+   *  construct a rows-by-columns sized zero-matrix.
+   */
+  public static zeroMatrix(rows: number, columns: number): Matrix {
+    return new Matrix(rows, columns);
+  }
+  /**
+   * construct a Matrix from an existing array.
+   * validates that the array is the correct size, given the number of rows and columns.
+   * in the case that the array is the incorrect size, returns an Either.Left,
+   * otherwise returns an Either.Right of the constructed Matrix
+   */
+  public static fromArray(
+    rows: number,
+    columns: number,
+    array: Array<number>
+  ): FineResult<string, Matrix> {
+    return Matrix.invalidConstructor(array, rows, columns)
+      ? left(Matrix.ERR_CANNOT_CONSTRUCT_INVALID_LENGTH)
+      : right(new Matrix(rows, columns, array));
+  }
+  public static rowFromPos3D(pos3D: IPosition3D): Matrix {
+    return new Matrix(1, 3, pos3D.value());
+  }
 
-    public static columnFromPos3D(pos3D: IPosition3D): Matrix {
-        return new Matrix(3, 1, pos3D.value());
-    }
+  public static columnFromPos3D(pos3D: IPosition3D): Matrix {
+    return new Matrix(3, 1, pos3D.value());
+  }
 
-    public static columnFromVector(vec: IVector): Matrix {
-        return new Matrix(vec.dimensionality(), 1, vec.value());
-    }
+  public static columnFromVector(vec: IVector): Matrix {
+    return new Matrix(vec.dimensionality(), 1, vec.value());
+  }
 
-    private static invalidConstructor(
-        arr: Array<number>,
-        rows: number,
-        cols: number,
-    ): boolean {
-        return arr.length !== 0 && arr.length !== rows * cols;
-    }
+  private static invalidConstructor(
+    arr: Array<number>,
+    rows: number,
+    cols: number
+  ): boolean {
+    return arr.length !== 0 && arr.length !== rows * cols;
+  }
 
-    private _contents: Array<number> = [];
-    /**
-     * initialContents are not validated when called directly
-     */
-    constructor(
-        private _rows: number,
-        private _columns: number,
-        initialContents: Array<number> = [],
-    ) {
-        this._contents = this.contents(
-            initialContents,
-            this._rows * this._columns,
-        );
-    }
+  private _contents: Array<number> = [];
+  /**
+   * initialContents are not validated when called directly
+   */
+  constructor(
+    private _rows: number,
+    private _columns: number,
+    initialContents: Array<number> = []
+  ) {
+    this._contents = this.contents(initialContents, this._rows * this._columns);
+  }
 
-    public rows(): number {
-        return this._rows;
-    }
+  public rows(): number {
+    return this._rows;
+  }
 
-    public columns(): number {
-        return this._columns;
-    }
+  public columns(): number {
+    return this._columns;
+  }
 
-    /**
-     * sum two Matrices.
-     */
-    public sum(rightMatrix: IMatrix): FineResult<string, Matrix> {
-        if (!this.matchesDimensions(rightMatrix)) {
-            return left(Matrix.ERR_CANNOT_ADD_DIMENSIONS_DIFFER);
-        }
-        return right(
-            new Matrix(
-                this._rows,
-                this._columns,
-                this._contents.map((val, i) => rightMatrix.value()[i] + val),
-            ),
-        );
+  /**
+   * sum two Matrices.
+   */
+  public sum(rightMatrix: IMatrix): FineResult<string, Matrix> {
+    if (!this.matchesDimensions(rightMatrix)) {
+      return left(Matrix.ERR_CANNOT_ADD_DIMENSIONS_DIFFER);
     }
-    public value(): Array<number> {
-        return this._contents;
+    return right(
+      new Matrix(
+        this._rows,
+        this._columns,
+        this._contents.map((val, i) => rightMatrix.value()[i] + val)
+      )
+    );
+  }
+  public value(): Array<number> {
+    return this._contents;
+  }
+  public matchesDimensions(n: IMatrix) {
+    return this._rows === n.rows() && this._columns === n.columns();
+  }
+  public scale(scalar: number): Matrix {
+    return new Matrix(
+      this._rows,
+      this._columns,
+      this._contents.map(val => val * scalar)
+    );
+  }
+  public row(rowIndex: number): FineResult<string, IVector> {
+    if (rowIndex < this._rows) {
+      return right<string, IVector>(
+        new Vector(
+          this._columns,
+          new Range(0, this._columns - 1)
+            .map(colIndex => rowIndex * this._columns + colIndex)
+            .map(i => this._contents[i])
+        )
+      );
+    } else {
+      return left<string, Vector>(Matrix.ERR_INDEX_OUT_OF_BOUNDS);
     }
-    public matchesDimensions(n: IMatrix) {
-        return this._rows === n.rows() && this._columns === n.columns();
+  }
+  public column(colIndex: number): FineResult<string, IVector> {
+    if (colIndex < this._columns) {
+      return right<string, Vector>(
+        new Vector(
+          this._rows,
+          new Range(0, this._rows - 1)
+            .map(rowIndex => rowIndex * this._columns + colIndex)
+            .map(i => this._contents[i])
+        )
+      );
+    } else {
+      return left<string, Vector>(Matrix.ERR_INDEX_OUT_OF_BOUNDS);
     }
-    public scale(scalar: number): Matrix {
-        return new Matrix(
-            this._rows,
-            this._columns,
-            this._contents.map(val => val * scalar),
-        );
-    }
-    public row(rowIndex: number) {
-        if (rowIndex < this._rows) {
-            return right<string, IVector>(
-                new Vector(
-                    this._columns,
-                    new Range(0, this._columns - 1)
-                        .map(colIndex => rowIndex * this._columns + colIndex)
-                        .map(i => this._contents[i]),
-                ),
-            );
-        } else {
-            return left<string, Vector>(Matrix.ERR_INDEX_OUT_OF_BOUNDS);
-        }
-    }
-    public column(colIndex: number) {
-        if (colIndex < this._columns) {
-            return right<string, Vector>(
-                new Vector(
-                    this._rows,
-                    new Range(0, this._rows - 1)
-                        .map(rowIndex => rowIndex * this._columns + colIndex)
-                        .map(i => this._contents[i]),
-                ),
-            );
-        } else {
-            return left<string, Vector>(Matrix.ERR_INDEX_OUT_OF_BOUNDS);
-        }
-    }
-    public multiply(rightMatrix: IMatrix): FineResult<string, Matrix> {
-        // matrix multiplication can only occur if the number of the left Matrix's rows
-        //   are equal to the number of the right Matrix's columns
-        return this.columns() !== rightMatrix.rows()
-            ? left(Matrix.ERR_CANNOT_MULTIPLY_INCOMPATIBLE_DIMENSIONS)
-            : new ZeroArray(this.rows())
-                  // first build an array of left row and right col dot results
-                  .map((_, rowIndex) =>
-                      new ZeroArray(rightMatrix.columns()).map((_, colIndex) =>
-                          this.row(rowIndex).chain(row =>
-                              rightMatrix
-                                  .column(colIndex)
-                                  .map(col => row.dot(col)),
-                          ),
-                      ),
-                  )
-                  // we've ended up with an Array<Array<Result<string, number>>> so reduce it into a single level of array
-                  // (this is why chain exists on an Either, stops us from getting Either<string, Either<string, T>>)
-                  .reduce((l, r) => l.concat(r), [])
-                  // swap an array of eithers into an either of an array
-                  // this will preserve the first Left to occur, I believe
-                  .reduce(
-                      (l, r) => l.chain(dots => r.map(dot => dots.concat(dot))),
-                      right<string, Array<number>>([]),
-                  )
-                  .map(
-                      startingValues =>
-                          new Matrix(
-                              this.rows(),
-                              rightMatrix.columns(),
-                              startingValues,
-                          ),
-                  );
-    }
+  }
+  public multiply(rightMatrix: IMatrix): FineResult<string, Matrix> {
+    // matrix multiplication can only occur if the number of the left Matrix's rows
+    //   are equal to the number of the right Matrix's columns
+    return this.columns() !== rightMatrix.rows()
+      ? left(Matrix.ERR_CANNOT_MULTIPLY_INCOMPATIBLE_DIMENSIONS)
+      : new ZeroArray(this.rows())
+          // first build an array of left row and right col dot results
+          .map((_, rowIndex) =>
+            new ZeroArray(rightMatrix.columns()).map((_, colIndex) =>
+              this.row(rowIndex).chain(row =>
+                rightMatrix.column(colIndex).map(col => row.dot(col))
+              )
+            )
+          )
+          // we've ended up with an Array<Array<Result<string, number>>> so reduce it into a single level of array
+          // (this is why chain exists on an Either, stops us from getting Either<string, Either<string, T>>)
+          .reduce((l, r) => l.concat(r), [])
+          // swap an array of eithers into an either of an array
+          // this will preserve the first Left to occur, I believe
+          .reduce(
+            (l, r) => l.chain(dots => r.map(dot => dots.concat(dot))),
+            right<string, Array<number>>([])
+          )
+          .map(
+            startingValues =>
+              new Matrix(this.rows(), rightMatrix.columns(), startingValues)
+          );
+  }
 
-    public transpose() {
-        return (
-            new Range(0, this.columns() - 1)
-                .map(i => this.column(i))
-                .map(eitherCol => eitherCol.map(col => col.value()))
-                // from an Array<Either<string, number[]>> to an Either<string, Array<number>>
-                .reduce(
-                    (l, r) => l.chain(mat => r.map(row => mat.concat(row))),
-                    right<string, Array<number>>([]),
-                )
-                .map(
-                    (startingValue: Array<number>) =>
-                        new Matrix(this.columns(), this.rows(), startingValue),
-                )
-        );
-    }
+  public transpose(): FineResult<string, Matrix> {
+    return (
+      new Range(0, this.columns() - 1)
+        .map(i => this.column(i))
+        .map(eitherCol => eitherCol.map(col => col.value()))
+        // from an Array<Either<string, number[]>> to an Either<string, Array<number>>
+        .reduce(
+          (l, r) => l.chain(mat => r.map(row => mat.concat(row))),
+          right<string, Array<number>>([])
+        )
+        .map(
+          (startingValue: Array<number>) =>
+            new Matrix(this.columns(), this.rows(), startingValue)
+        )
+    );
+  }
 
-    public map(fn: (ns: Array<number>) => Array<number>) {
-        return new Matrix(this.rows(), this.columns(), fn(this.value()));
-    }
+  public map(fn: (ns: Array<number>) => Array<number>) {
+    return new Matrix(this.rows(), this.columns(), fn(this.value()));
+  }
 
-    /**
-     * given an empty array, contents will return an array of the desired length filled with the given value
-     * given a non-empty array, contents will simply return the array
-     */
-    private contents(arr: Array<number>, desiredLength: number): Array<number> {
-        return arr.length === 0 ? new ZeroArray(desiredLength) : arr;
-    }
+  /**
+   * given an empty array, contents will return an array of the desired length filled with the given value
+   * given a non-empty array, contents will simply return the array
+   */
+  private contents(arr: Array<number>, desiredLength: number): Array<number> {
+    return arr.length === 0 ? new ZeroArray(desiredLength) : arr;
+  }
 }

--- a/src/Matrix/Matrix.ts
+++ b/src/Matrix/Matrix.ts
@@ -12,186 +12,196 @@ import { FineResult } from '../interface';
  * a general i-by-j Matrix of numbers
  */
 export class Matrix implements IMatrix {
-  public static ERR_CANNOT_CONSTRUCT_INVALID_LENGTH =
-    '[Matrix]: unable to construct Matrix with initial contents of invalid length';
-  public static ERR_CANNOT_ADD_DIMENSIONS_DIFFER =
-    '[Matrix]: unable to add matrices with differing dimensions';
-  public static ERR_CANNOT_MULTIPLY_INCOMPATIBLE_DIMENSIONS =
-    '[Matrix]: Unable to multiply matrices with incompatible dimensions';
-  public static ERR_INDEX_OUT_OF_BOUNDS =
-    '[Matrix]: Cannot retrieve, index provided is out of bounds';
-  /**
-   *  construct a rows-by-columns sized zero-matrix.
-   */
-  public static zeroMatrix(rows: number, columns: number): Matrix {
-    return new Matrix(rows, columns);
-  }
-  /**
-   * construct a Matrix from an existing array.
-   * validates that the array is the correct size, given the number of rows and columns.
-   * in the case that the array is the incorrect size, returns an Either.Left,
-   * otherwise returns an Either.Right of the constructed Matrix
-   */
-  public static fromArray(
-    rows: number,
-    columns: number,
-    array: Array<number>
-  ): FineResult<string, Matrix> {
-    return Matrix.invalidConstructor(array, rows, columns)
-      ? left(Matrix.ERR_CANNOT_CONSTRUCT_INVALID_LENGTH)
-      : right(new Matrix(rows, columns, array));
-  }
-  public static rowFromPos3D(pos3D: IPosition3D): Matrix {
-    return new Matrix(1, 3, pos3D.value());
-  }
-
-  public static columnFromPos3D(pos3D: IPosition3D): Matrix {
-    return new Matrix(3, 1, pos3D.value());
-  }
-
-  public static columnFromVector(vec: IVector): Matrix {
-    return new Matrix(vec.dimensionality(), 1, vec.value());
-  }
-
-  private static invalidConstructor(
-    arr: Array<number>,
-    rows: number,
-    cols: number
-  ): boolean {
-    return arr.length !== 0 && arr.length !== rows * cols;
-  }
-
-  private _contents: Array<number> = [];
-  /**
-   * initialContents are not validated when called directly
-   */
-  constructor(
-    private _rows: number,
-    private _columns: number,
-    initialContents: Array<number> = []
-  ) {
-    this._contents = this.contents(initialContents, this._rows * this._columns);
-  }
-
-  public rows(): number {
-    return this._rows;
-  }
-
-  public columns(): number {
-    return this._columns;
-  }
-
-  /**
-   * sum two Matrices.
-   */
-  public sum(rightMatrix: IMatrix): FineResult<string, Matrix> {
-    if (!this.matchesDimensions(rightMatrix)) {
-      return left(Matrix.ERR_CANNOT_ADD_DIMENSIONS_DIFFER);
+    public static ERR_CANNOT_CONSTRUCT_INVALID_LENGTH =
+        '[Matrix]: unable to construct Matrix with initial contents of invalid length';
+    public static ERR_CANNOT_ADD_DIMENSIONS_DIFFER =
+        '[Matrix]: unable to add matrices with differing dimensions';
+    public static ERR_CANNOT_MULTIPLY_INCOMPATIBLE_DIMENSIONS =
+        '[Matrix]: Unable to multiply matrices with incompatible dimensions';
+    public static ERR_INDEX_OUT_OF_BOUNDS =
+        '[Matrix]: Cannot retrieve, index provided is out of bounds';
+    /**
+     *  construct a rows-by-columns sized zero-matrix.
+     */
+    public static zeroMatrix(rows: number, columns: number): Matrix {
+        return new Matrix(rows, columns);
     }
-    return right(
-      new Matrix(
-        this._rows,
-        this._columns,
-        this._contents.map((val, i) => rightMatrix.value()[i] + val)
-      )
-    );
-  }
-  public value(): Array<number> {
-    return this._contents;
-  }
-  public matchesDimensions(n: IMatrix) {
-    return this._rows === n.rows() && this._columns === n.columns();
-  }
-  public scale(scalar: number): Matrix {
-    return new Matrix(
-      this._rows,
-      this._columns,
-      this._contents.map(val => val * scalar)
-    );
-  }
-  public row(rowIndex: number): FineResult<string, IVector> {
-    if (rowIndex < this._rows) {
-      return right<string, IVector>(
-        new Vector(
-          this._columns,
-          new Range(0, this._columns - 1)
-            .map(colIndex => rowIndex * this._columns + colIndex)
-            .map(i => this._contents[i])
-        )
-      );
-    } else {
-      return left<string, Vector>(Matrix.ERR_INDEX_OUT_OF_BOUNDS);
+    /**
+     * construct a Matrix from an existing array.
+     * validates that the array is the correct size, given the number of rows and columns.
+     * in the case that the array is the incorrect size, returns an Either.Left,
+     * otherwise returns an Either.Right of the constructed Matrix
+     */
+    public static fromArray(
+        rows: number,
+        columns: number,
+        array: Array<number>
+    ): FineResult<string, Matrix> {
+        return Matrix.invalidConstructor(array, rows, columns)
+            ? left(Matrix.ERR_CANNOT_CONSTRUCT_INVALID_LENGTH)
+            : right(new Matrix(rows, columns, array));
     }
-  }
-  public column(colIndex: number): FineResult<string, IVector> {
-    if (colIndex < this._columns) {
-      return right<string, Vector>(
-        new Vector(
-          this._rows,
-          new Range(0, this._rows - 1)
-            .map(rowIndex => rowIndex * this._columns + colIndex)
-            .map(i => this._contents[i])
-        )
-      );
-    } else {
-      return left<string, Vector>(Matrix.ERR_INDEX_OUT_OF_BOUNDS);
+    public static rowFromPos3D(pos3D: IPosition3D): Matrix {
+        return new Matrix(1, 3, pos3D.value());
     }
-  }
-  public multiply(rightMatrix: IMatrix): FineResult<string, Matrix> {
-    // matrix multiplication can only occur if the number of the left Matrix's rows
-    //   are equal to the number of the right Matrix's columns
-    return this.columns() !== rightMatrix.rows()
-      ? left(Matrix.ERR_CANNOT_MULTIPLY_INCOMPATIBLE_DIMENSIONS)
-      : new ZeroArray(this.rows())
-          // first build an array of left row and right col dot results
-          .map((_, rowIndex) =>
-            new ZeroArray(rightMatrix.columns()).map((_, colIndex) =>
-              this.row(rowIndex).chain(row =>
-                rightMatrix.column(colIndex).map(col => row.dot(col))
-              )
+
+    public static columnFromPos3D(pos3D: IPosition3D): Matrix {
+        return new Matrix(3, 1, pos3D.value());
+    }
+
+    public static columnFromVector(vec: IVector): Matrix {
+        return new Matrix(vec.dimensionality(), 1, vec.value());
+    }
+
+    private static invalidConstructor(
+        arr: Array<number>,
+        rows: number,
+        cols: number
+    ): boolean {
+        return arr.length !== 0 && arr.length !== rows * cols;
+    }
+
+    private _contents: Array<number> = [];
+    /**
+     * initialContents are not validated when called directly
+     */
+    constructor(
+        private _rows: number,
+        private _columns: number,
+        initialContents: Array<number> = []
+    ) {
+        this._contents = this.contents(
+            initialContents,
+            this._rows * this._columns
+        );
+    }
+
+    public rows(): number {
+        return this._rows;
+    }
+
+    public columns(): number {
+        return this._columns;
+    }
+
+    /**
+     * sum two Matrices.
+     */
+    public sum(rightMatrix: IMatrix): FineResult<string, Matrix> {
+        if (!this.matchesDimensions(rightMatrix)) {
+            return left(Matrix.ERR_CANNOT_ADD_DIMENSIONS_DIFFER);
+        }
+        return right(
+            new Matrix(
+                this._rows,
+                this._columns,
+                this._contents.map((val, i) => rightMatrix.value()[i] + val)
             )
-          )
-          // we've ended up with an Array<Array<Result<string, number>>> so reduce it into a single level of array
-          // (this is why chain exists on an Either, stops us from getting Either<string, Either<string, T>>)
-          .reduce((l, r) => l.concat(r), [])
-          // swap an array of eithers into an either of an array
-          // this will preserve the first Left to occur, I believe
-          .reduce(
-            (l, r) => l.chain(dots => r.map(dot => dots.concat(dot))),
-            right<string, Array<number>>([])
-          )
-          .map(
-            startingValues =>
-              new Matrix(this.rows(), rightMatrix.columns(), startingValues)
-          );
-  }
+        );
+    }
+    public value(): Array<number> {
+        return this._contents;
+    }
+    public matchesDimensions(n: IMatrix) {
+        return this._rows === n.rows() && this._columns === n.columns();
+    }
+    public scale(scalar: number): Matrix {
+        return new Matrix(
+            this._rows,
+            this._columns,
+            this._contents.map((val) => val * scalar)
+        );
+    }
+    public row(rowIndex: number): FineResult<string, IVector> {
+        if (rowIndex < this._rows) {
+            return right<string, IVector>(
+                new Vector(
+                    this._columns,
+                    new Range(0, this._columns - 1)
+                        .map((colIndex) => rowIndex * this._columns + colIndex)
+                        .map((i) => this._contents[i])
+                )
+            );
+        } else {
+            return left<string, Vector>(Matrix.ERR_INDEX_OUT_OF_BOUNDS);
+        }
+    }
+    public column(colIndex: number): FineResult<string, IVector> {
+        if (colIndex < this._columns) {
+            return right<string, Vector>(
+                new Vector(
+                    this._rows,
+                    new Range(0, this._rows - 1)
+                        .map((rowIndex) => rowIndex * this._columns + colIndex)
+                        .map((i) => this._contents[i])
+                )
+            );
+        } else {
+            return left<string, Vector>(Matrix.ERR_INDEX_OUT_OF_BOUNDS);
+        }
+    }
+    public multiply(rightMatrix: IMatrix): FineResult<string, Matrix> {
+        // matrix multiplication can only occur if the number of the left Matrix's rows
+        //   are equal to the number of the right Matrix's columns
+        return this.columns() !== rightMatrix.rows()
+            ? left(Matrix.ERR_CANNOT_MULTIPLY_INCOMPATIBLE_DIMENSIONS)
+            : new ZeroArray(this.rows())
+                  // first build an array of left row and right col dot results
+                  .map((_, rowIndex) =>
+                      new ZeroArray(rightMatrix.columns()).map((_, colIndex) =>
+                          this.row(rowIndex).chain((row) =>
+                              rightMatrix
+                                  .column(colIndex)
+                                  .map((col) => row.dot(col))
+                          )
+                      )
+                  )
+                  // we've ended up with an Array<Array<Result<string, number>>> so reduce it into a single level of array
+                  // (this is why chain exists on an Either, stops us from getting Either<string, Either<string, T>>)
+                  .reduce((l, r) => l.concat(r), [])
+                  // swap an array of eithers into an either of an array
+                  // this will preserve the first Left to occur, I believe
+                  .reduce(
+                      (l, r) =>
+                          l.chain((dots) => r.map((dot) => dots.concat(dot))),
+                      right<string, Array<number>>([])
+                  )
+                  .map(
+                      (startingValues) =>
+                          new Matrix(
+                              this.rows(),
+                              rightMatrix.columns(),
+                              startingValues
+                          )
+                  );
+    }
 
-  public transpose(): FineResult<string, Matrix> {
-    return (
-      new Range(0, this.columns() - 1)
-        .map(i => this.column(i))
-        .map(eitherCol => eitherCol.map(col => col.value()))
-        // from an Array<Either<string, number[]>> to an Either<string, Array<number>>
-        .reduce(
-          (l, r) => l.chain(mat => r.map(row => mat.concat(row))),
-          right<string, Array<number>>([])
-        )
-        .map(
-          (startingValue: Array<number>) =>
-            new Matrix(this.columns(), this.rows(), startingValue)
-        )
-    );
-  }
+    public transpose(): FineResult<string, Matrix> {
+        return (
+            new Range(0, this.columns() - 1)
+                .map((i) => this.column(i))
+                .map((eitherCol) => eitherCol.map((col) => col.value()))
+                // from an Array<Either<string, number[]>> to an Either<string, Array<number>>
+                .reduce(
+                    (l, r) => l.chain((mat) => r.map((row) => mat.concat(row))),
+                    right<string, Array<number>>([])
+                )
+                .map(
+                    (startingValue: Array<number>) =>
+                        new Matrix(this.columns(), this.rows(), startingValue)
+                )
+        );
+    }
 
-  public map(fn: (ns: Array<number>) => Array<number>) {
-    return new Matrix(this.rows(), this.columns(), fn(this.value()));
-  }
+    public map(fn: (ns: Array<number>) => Array<number>) {
+        return new Matrix(this.rows(), this.columns(), fn(this.value()));
+    }
 
-  /**
-   * given an empty array, contents will return an array of the desired length filled with the given value
-   * given a non-empty array, contents will simply return the array
-   */
-  private contents(arr: Array<number>, desiredLength: number): Array<number> {
-    return arr.length === 0 ? new ZeroArray(desiredLength) : arr;
-  }
+    /**
+     * given an empty array, contents will return an array of the desired length filled with the given value
+     * given a non-empty array, contents will simply return the array
+     */
+    private contents(arr: Array<number>, desiredLength: number): Array<number> {
+        return arr.length === 0 ? new ZeroArray(desiredLength) : arr;
+    }
 }

--- a/src/Matrix/SquareMatrix/SquareMatrix.ts
+++ b/src/Matrix/SquareMatrix/SquareMatrix.ts
@@ -1,9 +1,10 @@
-import { Either, left, right } from 'fp-ts/lib/Either';
+import { left, right } from 'fp-ts/lib/Either';
 
 import { ISquareMatrix } from './interface';
 import { IMatrix } from '../interface';
 import { Matrix } from '../Matrix';
 import { IVector } from '../../Vector';
+import { FineResult } from '../../interface';
 
 /**
  * a Matrix which contains the same number of rows and columns.
@@ -49,13 +50,13 @@ export class SquareMatrix implements ISquareMatrix {
             this._matrix.scale(scalar).value(),
         );
     }
-    public row(index: number): Either<string, IVector> {
+    public row(index: number): FineResult<string, IVector> {
         return this._matrix.row(index);
     }
-    public column(index: number): Either<string, IVector> {
+    public column(index: number): FineResult<string, IVector> {
         return this._matrix.column(index);
     }
-    public multiply(right: IMatrix): Either<string, IMatrix> {
+    public multiply(right: IMatrix): FineResult<string, IMatrix> {
         return this._matrix.multiply(right);
     }
     public sum(right: IMatrix) {
@@ -66,7 +67,7 @@ export class SquareMatrix implements ISquareMatrix {
     public value() {
         return this._matrix.value();
     }
-    public transpose(): Either<string, SquareMatrix> {
+    public transpose(): FineResult<string, SquareMatrix> {
         return this._matrix
             .transpose()
             .map(matrix => new SquareMatrix(this.rows(), matrix.value()));
@@ -82,7 +83,7 @@ export class SquareMatrix implements ISquareMatrix {
      * for Matrices of different sizes, returns a Left of
      *      the string {@link SquareMatrix.ERR_NO_DETERMINANT_WRONG_SIZE}
      */
-    public determinant(): Either<string, number> {
+    public determinant(): FineResult<string, number> {
         if (this.rows() === 2) {
             const value = this._matrix.value();
             // prettier-ignore
@@ -115,7 +116,7 @@ export class SquareMatrix implements ISquareMatrix {
      *  for singular Matrices (those without an inverse),
      *      returns a Left of the string {@link SquareMatrix.ERR_CANNOT_INVERT_SINGULAR}
      */
-    public inverse(): Either<string, SquareMatrix> {
+    public inverse(): FineResult<string, SquareMatrix> {
         return (
             this.determinant()
                 // explainer comments for what might look like 'weird' Either stuff.

--- a/src/Matrix/SquareMatrix/SquareMatrix.ts
+++ b/src/Matrix/SquareMatrix/SquareMatrix.ts
@@ -130,7 +130,7 @@ export class SquareMatrix implements ISquareMatrix {
                             ? left(SquareMatrix.ERR_CANNOT_INVERT_SINGULAR)
                             : right(determinant),
                 )
-                // convert error state for no determinant when matrix too large to cannot invert, matrix too large
+                // convert error state for 'no determinant when matrix too large' to 'cannot invert, matrix too large'
                 .mapLeft(
                     errorMessage =>
                         errorMessage ===

--- a/src/Matrix/SquareMatrix/SquareMatrix.ts
+++ b/src/Matrix/SquareMatrix/SquareMatrix.ts
@@ -59,7 +59,7 @@ export class SquareMatrix implements ISquareMatrix {
     public multiply(right: IMatrix): FineResult<string, IMatrix> {
         return this._matrix.multiply(right);
     }
-    public sum(right: IMatrix) {
+    public sum(right: IMatrix): FineResult<string, SquareMatrix> {
         return this._matrix
             .sum(right)
             .map(result => new SquareMatrix(this.rows(), result.value()));

--- a/src/Matrix/SquareMatrix/interface.ts
+++ b/src/Matrix/SquareMatrix/interface.ts
@@ -1,13 +1,13 @@
-import { Either } from 'fp-ts/lib/Either';
+import { FineResult } from '../../interface';
 import { IMatrix } from '../interface';
 
 export interface ISquareMatrix extends IMatrix {
     /**
      * the determinant of this SquareMatrix
      */
-    determinant(): Either<string, number>;
+    determinant(): FineResult<string, number>;
     /**
      * the inverse of this SquareMatrix
      */
-    inverse(): Either<string, ISquareMatrix>;
+    inverse(): FineResult<string, ISquareMatrix>;
 }

--- a/src/Matrix/interface.ts
+++ b/src/Matrix/interface.ts
@@ -1,8 +1,7 @@
-import { Either } from 'fp-ts/lib/Either';
-
 import { IValue } from '../Value';
 import { ISum } from '../Sum';
 import { IVector } from '../Vector';
+import { FineResult } from '../interface';
 
 export interface IMatrix extends ISum<IMatrix>, IValue<Array<number>> {
     /** does an IMatrix match dimensions? */
@@ -16,20 +15,20 @@ export interface IMatrix extends ISum<IMatrix>, IValue<Array<number>> {
     /**
      * fetch the row at index, given a zero-based index
      */
-    row(index: number): Either<string, IVector>;
+    row(index: number): FineResult<string, IVector>;
     /**
      * fetch the column at index, given a zero-based index
      */
-    column(index: number): Either<string, IVector>;
+    column(index: number): FineResult<string, IVector>;
     /**
      * multiply two compatible Matrices together
      */
-    multiply(right: IMatrix): Either<string, IMatrix>;
+    multiply(right: IMatrix): FineResult<string, IMatrix>;
     /**
      * transpose the provided Matrix
      * https://en.wikipedia.org/wiki/Transpose
      */
-    transpose(): Either<string, IMatrix>;
+    transpose(): FineResult<string, IMatrix>;
     /**
      * apply the provided function to the entire contents of the Matrix, producing a new Matrix.
      * The returned array is expected to be of the same dimensionality as the provided one.

--- a/src/OrientedBoundingBox/OrientedBoundingBox.ts
+++ b/src/OrientedBoundingBox/OrientedBoundingBox.ts
@@ -3,8 +3,8 @@ import { AffineTransform3D } from '../AffineTransform';
 import { IPosition3D } from '../Position';
 
 import { IOrientedBoundingBox } from './interface';
-import { Either } from 'fp-ts/lib/Either';
 import { CubeCorners } from '../Cube';
+import { FineResult } from '../interface';
 
 export class OrientedBoundingBox implements IOrientedBoundingBox {
     private _aabb: AxisAlignedBoundingBox;
@@ -28,7 +28,7 @@ export class OrientedBoundingBox implements IOrientedBoundingBox {
     public rawAxisAlignedBoundingBox() {
         return this._aabb;
     }
-    public corners(): Either<string, CubeCorners> {
+    public corners(): FineResult<string, CubeCorners> {
         return this._transform.cornersFromAxisAlignedBoundingBox(this._aabb);
     }
     public axisAlignedBoundingBox() {

--- a/src/OrientedBoundingBox/OrientedBoundingBox.ts
+++ b/src/OrientedBoundingBox/OrientedBoundingBox.ts
@@ -31,10 +31,10 @@ export class OrientedBoundingBox implements IOrientedBoundingBox {
     public corners(): FineResult<string, CubeCorners> {
         return this._transform.cornersFromAxisAlignedBoundingBox(this._aabb);
     }
-    public axisAlignedBoundingBox() {
+    public axisAlignedBoundingBox(): FineResult<string, AxisAlignedBoundingBox> {
         return this._transform.axisAlignedBoundingBox(this._aabb);
     }
-    public union(right: IOrientedBoundingBox) {
+    public union(right: IOrientedBoundingBox): FineResult<string, OrientedBoundingBox> {
         return right
             .axisAlignedBoundingBox()
             .chain(rightAABB =>

--- a/src/OrientedBoundingBox/interface.ts
+++ b/src/OrientedBoundingBox/interface.ts
@@ -1,9 +1,8 @@
-import { Either } from 'fp-ts/lib/Either';
-
 import { IPosition3D } from '../Position';
 import { AxisAlignedBoundingBox } from '../AxisAlignedBoundingBox';
 import { AffineTransform3D } from '../AffineTransform';
 import { CubeCorners } from '../Cube';
+import { FineResult } from '../interface';
 
 export interface IOrientedBoundingBox {
     /**
@@ -17,7 +16,7 @@ export interface IOrientedBoundingBox {
     /**
      * the corners of the OrientedBoundedBox
      */
-    corners(): Either<string, CubeCorners>;
+    corners(): FineResult<string, CubeCorners>;
     /**
      * the internal AxisAlignedBoundingBox this OrientedBoundingBox is constructed with
      */
@@ -25,11 +24,11 @@ export interface IOrientedBoundingBox {
     /**
      * return the enclosing AxisAlignedBoundingBox of this OrientedBoundingBox
      */
-    axisAlignedBoundingBox(): Either<string, AxisAlignedBoundingBox>;
+    axisAlignedBoundingBox(): FineResult<string, AxisAlignedBoundingBox>;
     /**
      * union of two OrientedBoundingBoxes, produces a new OBB in the left OBBs space
      */
-    union(right: IOrientedBoundingBox): Either<string, IOrientedBoundingBox>;
+    union(right: IOrientedBoundingBox): FineResult<string, IOrientedBoundingBox>;
     /**
      * the affine transform in 3D space associated with this IOrientedBoundingBox
      */

--- a/src/Sum/interface.ts
+++ b/src/Sum/interface.ts
@@ -1,9 +1,8 @@
-import { Either } from 'fp-ts/lib/Either';
+import { FineResult } from '../interface';
 
-// TODO: add index.ts
 export interface ISum<T> {
-    /**
-     * produce a sum of the left and right operands
-     */
-    sum: (right: T) => Either<string, T>;
+  /**
+   * produce a sum of the left and right operands
+   */
+  sum: (right: T) => FineResult<string, T>;
 }

--- a/src/Vector/interface.ts
+++ b/src/Vector/interface.ts
@@ -1,5 +1,5 @@
 import { IValue } from '../Value/interface';
-import { Either } from 'fp-ts/lib/Either';
+import { FineResult } from '../interface';
 
 export interface IVector extends IValue<Array<number>> {
     /**
@@ -12,5 +12,5 @@ export interface IVector extends IValue<Array<number>> {
      */
     dot(right: IVector): number;
     scale(scalar: number): IVector;
-    sum(right: IVector): Either<string, IVector>;
+    sum(right: IVector): FineResult<string, IVector>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ import {
   Position2D
 } from './Position';
 import { IVector, Vector, Vector2D } from './Vector';
-import { CubeCorners } from './Cube';
+import { CubeCorners, NamedCubeCorners } from './Cube';
 import { FineResult } from './interface';
 
 export { FineResult };
@@ -56,5 +56,6 @@ export {
   Position2D,
   Vector,
   Vector2D,
-  CubeCorners
+  CubeCorners,
+  NamedCubeCorners
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,36 +3,58 @@ import { ISum } from './Sum';
 import { ITranslatable } from './Translatable';
 import { IValue } from './Value';
 import { IAffineTransform, AffineTransform3D } from './AffineTransform';
-import { IAxisAlignedBoundingBox, AxisAlignedBoundingBox } from './AxisAlignedBoundingBox';
-import { IMatrix, ISquareMatrix, Matrix, SquareMatrix, SquareMatrix3D } from './Matrix';
-import { IOrientedBoundingBox, OrientedBoundingBox } from './OrientedBoundingBox';
-import { IPosition3D, IPosition2D, IPosition, Position3D, Position2D } from './Position';
+import {
+  IAxisAlignedBoundingBox,
+  AxisAlignedBoundingBox
+} from './AxisAlignedBoundingBox';
+import {
+  IMatrix,
+  ISquareMatrix,
+  Matrix,
+  SquareMatrix,
+  SquareMatrix3D
+} from './Matrix';
+import {
+  IOrientedBoundingBox,
+  OrientedBoundingBox
+} from './OrientedBoundingBox';
+import {
+  IPosition3D,
+  IPosition2D,
+  IPosition,
+  Position3D,
+  Position2D
+} from './Position';
 import { IVector, Vector, Vector2D } from './Vector';
 import { CubeCorners } from './Cube';
+import { FineResult } from './interface';
 
+export { FineResult };
 export {
-    IOrdinal,
-    ISum,
-    ITranslatable,
-    IValue,
-    IAffineTransform,
-    IAxisAlignedBoundingBox,
-    IMatrix,
-    ISquareMatrix,
-    IOrientedBoundingBox,
-    IPosition,
-    IPosition2D,
-    IPosition3D,
-    IVector,
-    AffineTransform3D,
-    AxisAlignedBoundingBox,
-    Matrix,
-    SquareMatrix,
-    SquareMatrix3D,
-    OrientedBoundingBox,
-    Position3D,
-    Position2D,
-    Vector,
-    Vector2D,
-    CubeCorners
+  IOrdinal,
+  ISum,
+  ITranslatable,
+  IValue,
+  IAffineTransform,
+  IAxisAlignedBoundingBox,
+  IMatrix,
+  ISquareMatrix,
+  IOrientedBoundingBox,
+  IPosition,
+  IPosition2D,
+  IPosition3D,
+  IVector
+};
+export {
+  AffineTransform3D,
+  AxisAlignedBoundingBox,
+  Matrix,
+  SquareMatrix,
+  SquareMatrix3D,
+  OrientedBoundingBox,
+  Position3D,
+  Position2D,
+  Vector,
+  Vector2D,
+  CubeCorners
 };

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,0 +1,3 @@
+import { Either } from 'fp-ts/lib/Either';
+
+export type FineResult<T extends string, U> = Either<T, U>;


### PR DESCRIPTION
Create and use a `FineResult` type. A `FineResult` is an `fp-ts` `Either` type where the `Left` is restricted to extending `string`.

This work enables 3rd parties to easier implement `fine` interfaces. The interfaces rely on the Either type heavily, and it's absence causes problems with TypeScript. Specifically, TypeScript complains about a private type being used - which is fair enough. What's more, other versions of `fp-ts` would be incompatible and seem to cause TypeScript to hang indefinitely.

This change also leaves the ability for `fine` methods to specify exactly what possible `Left`s might be returned by a function. For example, a method could return a `FineResult<'problem one' | 'problem two', IVector>` type.
