### PR TITLE
fix. add exact dependency to fp-ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "lint": "tslint --project ./tslint.json src/**/*.ts"
     },
     "dependencies": {
-        "fp-ts": "^1.8.1",
+        "fp-ts": "1.8.1",
         "lodash": "^4.17.11"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1136,7 +1136,7 @@ form-data@~2.3.2:
     combined-stream "1.0.6"
     mime-types "^2.1.12"
 
-fp-ts@^1.8.1:
+fp-ts@1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-1.8.1.tgz#46800e05a814968f79664a76a80d6c6d948c032e"
   integrity sha512-hcNjU4yFw2j0vqqTxJTptHAagA9KN5iaETmYGyMkoQcJzblVWq+7jEJdMy0CfJtVMjzTJn0sZIg+3Rfb+sAy4A==


### PR DESCRIPTION
later fp-ts minor versions break builds when not using typescript 3.0.0

As a result, I'm fixing the version to exactly 1.8.1, as this definitely
works.